### PR TITLE
Add ini-equivalent command line options

### DIFF
--- a/pytest_match_skip/check_skip_prefixes.py
+++ b/pytest_match_skip/check_skip_prefixes.py
@@ -17,11 +17,26 @@ def __matches_in_test_marks(mark_list, test_marks):
     return matches
 
 
+def __get_param(config, name):
+    """ Retrieve stringified option from parameters or ini config. """
+    value = config.getoption(name)
+    if value and isinstance(value, list):
+        return ' '.join(value)
+
+    if not value or value == '':
+        value = config.getini(name)
+
+    if value is None:
+        return ''
+
+    return value
+
+
 def check_skip_prefixes(item):
     """Checks a test item for any skip marks."""
     reason = None
 
-    all_skip_marks = item.config.getini('skip_marks')
+    all_skip_marks = __get_param(item.config, 'skip_marks')
 
     if all_skip_marks == '':
         # No skip_marks were found.
@@ -42,7 +57,8 @@ def check_skip_prefixes(item):
         reason = msg.format(**locals())
 
         # The test will be skipped, now check the important marks
-        all_important_marks = item.config.getini('important_marks').split(' ')
+        all_important_marks = __get_param(item.config,
+                                          'important_marks').split(' ')
         important_marks = __matches_in_test_marks(
             all_important_marks, test_marks
         )
@@ -51,7 +67,7 @@ def check_skip_prefixes(item):
     else:
         return
 
-    if item.config.getini('run_skips') == 'true':
+    if __get_param(item.config, 'run_skips') == 'true':
         msg = ('Running {item.name} despite the following skip marks:'
                ' {str_matches}.')
         item.config.hook.pytest_match_skip_run_skip_warning(
@@ -70,7 +86,7 @@ def check_skip_prefixes(item):
 
     item.config.hook.pytest_match_skip_reason(request=item, message=reason)
 
-    if item.config.getini('xfail_skips') == 'true':
+    if __get_param(item.config, 'xfail_skips') == 'true':
         pytest.xfail(reason)
     else:
         pytest.skip(reason)

--- a/pytest_match_skip/plugin.py
+++ b/pytest_match_skip/plugin.py
@@ -33,15 +33,37 @@ def pytest_addoption(parser):
         'skip_marks',
         'Tests with a matching mark will be skipped'
     )
+    parser.addoption(
+        '--skip_marks',
+        type=str,
+        action='append',
+        help='Tests with a matching mark will be skipped'
+    )
     parser.addini(
         'important_marks',
         'User will be warned if tests with this tag are skipped.'
+    )
+    parser.addoption(
+        '--important_marks',
+        type=str,
+        action='append',
+        help='User will be warned if tests with this tag are skipped.'
     )
     parser.addini(
         'run_skips',
         'If true, runs tests that are tagged for skipping.'
     )
+    parser.addoption(
+        '--run_skips',
+        type=bool,
+        help='If true, runs tests that are tagged for skipping.'
+    )
     parser.addini(
         'xfail_skips',
         'Instead of skipping, xfail the tagged tests'
+    )
+    parser.addoption(
+        '--xfail_skips',
+        type=bool,
+        help='Instead of skipping, xfail the tagged tests'
     )

--- a/tests/test_match_skip.py
+++ b/tests/test_match_skip.py
@@ -122,3 +122,65 @@ def test_multiple_tags_should_skip(testdir):
 
     # make sure that that we get a '0' exit code for the testsuite
     assert result.ret == 0
+
+
+def test_prefix_skipping_should_skip_options(testdir):
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.bug_666
+        def test_prefix_skipping():
+        # A mark with a prefix that indicates it should be skipped.
+        # This test should be skipped.
+            assert False
+
+
+        @pytest.mark.bug_667
+        @pytest.mark.bug_668
+        @pytest.mark.bug_669
+        def test_multiple_prefix_skipping():
+            # Multiple marks with a prefix that indicate it should be skipped.
+            # Every mark should be displayed in the skip reason.
+            # This test should be skipped.
+            assert False
+
+
+        @pytest.mark.issue_known_failure_888
+        def test_prefix_suffix_skipping():
+            # A mark where there are multiple wildcards.
+            # This test should be skipped.
+            assert False
+
+
+        @pytest.mark.bug_999
+        @pytest.mark.smoke
+        @pytest.mark.register_sanity
+        class TestMultipleTags:
+
+            def test_important_skipped(self):
+                # Multiple marks. One to indicate the test should be skipped,
+                # The other that the test is important.
+                # This test should be skipped, but a warning should display.
+                assert False
+    """)
+
+    result = testdir.runpytest(
+        '-v',
+        '--skip_mark=bug_.*', '--skip_mark=.*_tracker',
+        '--skip_mark=.*_known_failure_.*',
+        '--important_marks=smoke', '--important_marks=.*_sanity',
+        '--important_marks=important_.*',
+        '--run_skips=no',
+        '--xfail_skips=false',
+    )
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*::test_prefix_skipping SKIPPED',
+        '*::test_multiple_prefix_skipping SKIPPED',
+        '*::test_prefix_suffix_skipping SKIPPED',
+        '*::test_important_skipped SKIPPED',
+    ])
+
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0


### PR DESCRIPTION
Options are checked first, overriding ini configs if present.

The test is merely copied from the first test case and the ini settings used as options.